### PR TITLE
Revert PR #12

### DIFF
--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -84,6 +84,7 @@ type credentials struct {
 
 type schemaRequest struct {
 	Schema     string      `json:"schema"`
+	SchemaType string      `json:"schemaType"`
 	References []Reference `json:"references"`
 }
 
@@ -219,7 +220,7 @@ func (client *SchemaRegistryClient) CreateSchema(subject string, schema string,
 		references = make([]Reference, 0)
 	}
 
-	schemaReq := schemaRequest{Schema: schema, References: references}
+	schemaReq := schemaRequest{Schema: schema, SchemaType: schemaType.String(), References: references}
 	schemaBytes, err := json.Marshal(schemaReq)
 	if err != nil {
 		return nil, err

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -32,6 +32,7 @@ func TestSchemaRegistryClient_CreateSchemaWithoutReferences(t *testing.T) {
 		case "/subjects/test1-value/versions":
 			requestPayload := schemaRequest{
 				Schema:     "test2",
+				SchemaType: Protobuf.String(),
 				References: []Reference{},
 			}
 			expected, _ := json.Marshal(requestPayload)
@@ -73,7 +74,8 @@ func TestSchemaRegistryClient_CreateSchemaWithReferences(t *testing.T) {
 		switch req.URL.String() {
 		case "/subjects/test1-value/versions":
 			requestPayload := schemaRequest{
-				Schema: "test2",
+				Schema:     "test2",
+				SchemaType: Protobuf.String(),
 				References: []Reference{
 					{Name: "test3", Subject: "test4", Version: 1},
 				},


### PR DESCRIPTION
Revert PR #12 as `schemaType` is required for the latest API.
Add `schemaType` to the test suite.

Resolves #19