### PR TITLE
Add Semaphore to HTTP Requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.12
 
 require github.com/linkedin/goavro/v2 v2.9.7
 
-require github.com/stretchr/testify v1.3.0
+require (
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+)

--- a/go.sum
+++ b/go.sum
@@ -9,3 +9,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
As per #32, an inner semaphore will stop the srclient from causing significant overhead with too many open files error.

Please review.