### PR TITLE
Add references to Schema

### DIFF
--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -88,7 +88,7 @@ type Schema struct {
 	id         int
 	schema     string
 	version    int
-	References []Reference
+	references []Reference
 	codec      *goavro.Codec
 }
 
@@ -458,7 +458,7 @@ func (client *SchemaRegistryClient) getVersion(subject string, version string) (
 		id:         schemaResp.ID,
 		schema:     schemaResp.Schema,
 		version:    schemaResp.Version,
-		References: schemaResp.References,
+		references: schemaResp.References,
 		codec:      codec,
 	}
 
@@ -534,6 +534,11 @@ func (schema *Schema) Schema() string {
 // Version ensures access to Version
 func (schema *Schema) Version() int {
 	return schema.version
+}
+
+// Reference ensures access to Reference
+func (schema *Schema) Reference() []Reference {
+	return schema.references
 }
 
 // Codec ensures access to Codec

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -85,10 +85,11 @@ type Reference struct {
 // Schema is a data structure that holds all
 // the relevant information about schemas.
 type Schema struct {
-	id      int
-	schema  string
-	version int
-	codec   *goavro.Codec
+	id         int
+	schema     string
+	version    int
+	References []Reference
+	codec      *goavro.Codec
 }
 
 type credentials struct {
@@ -103,10 +104,11 @@ type schemaRequest struct {
 }
 
 type schemaResponse struct {
-	Subject string `json:"subject"`
-	Version int    `json:"version"`
-	Schema  string `json:"schema"`
-	ID      int    `json:"id"`
+	Subject    string      `json:"subject"`
+	Version    int         `json:"version"`
+	Schema     string      `json:"schema"`
+	ID         int         `json:"id"`
+	References []Reference `json:"references"`
 }
 
 type isCompatibleResponse struct {
@@ -423,8 +425,7 @@ func (client *SchemaRegistryClient) CodecCreationEnabled(value bool) {
 	client.codecCreationEnabled = value
 }
 
-func (client *SchemaRegistryClient) getVersion(subject string,
-	version string) (*Schema, error) {
+func (client *SchemaRegistryClient) getVersion(subject string, version string) (*Schema, error) {
 
 	if client.getCachingEnabled() {
 		cacheKey := cacheKey(subject, version)
@@ -454,10 +455,11 @@ func (client *SchemaRegistryClient) getVersion(subject string,
 		}
 	}
 	var schema = &Schema{
-		id:      schemaResp.ID,
-		schema:  schemaResp.Schema,
-		version: schemaResp.Version,
-		codec:   codec,
+		id:         schemaResp.ID,
+		schema:     schemaResp.Schema,
+		version:    schemaResp.Version,
+		References: schemaResp.References,
+		codec:      codec,
 	}
 
 	if client.getCachingEnabled() {

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -536,8 +536,8 @@ func (schema *Schema) Version() int {
 	return schema.version
 }
 
-// Reference ensures access to Reference
-func (schema *Schema) Reference() []Reference {
+// References ensures access to References
+func (schema *Schema) References() []Reference {
 	return schema.references
 }
 

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func bodyToString(in io.ReadCloser) string {
@@ -102,4 +103,79 @@ func TestSchemaRegistryClient_CreateSchemaWithArbitrarySubjectName(t *testing.T)
 	assert.Nil(t, schema.codec)
 	assert.Equal(t, schema.schema, "test2")
 	assert.Equal(t, schema.version, 1)
+}
+
+func TestSchemaRegistryClient_GetSchemaByVersionWithArbitrarySubjectWithReferences(t *testing.T) {
+	refs := []Reference{
+		{Name: "name1", Subject: "subject1", Version: 1},
+		{Name: "name2", Subject: "subject2", Version: 2},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		responsePayload := schemaResponse{
+			Subject:    "test1",
+			Version:    1,
+			Schema:     "payload",
+			ID:         1,
+			References: refs,
+		}
+		response, _ := json.Marshal(responsePayload)
+
+		switch req.URL.String() {
+		case "/subjects/test1/versions/1":
+			// Send response to be tested
+			rw.Write(response)
+		default:
+			require.Fail(t, "unhandled request")
+		}
+
+	}))
+
+	srClient := CreateSchemaRegistryClient(server.URL)
+	srClient.CodecCreationEnabled(false)
+	schema, err := srClient.GetSchemaByVersionWithArbitrarySubject("test1", 1)
+
+	// Test response
+	assert.NoError(t, err)
+	assert.Equal(t, schema.ID(), 1)
+	assert.Nil(t, schema.codec)
+	assert.Equal(t, schema.Schema(), "payload")
+	assert.Equal(t, schema.Version(), 1)
+	assert.Equal(t, schema.References(), refs)
+	assert.Equal(t, len(schema.References()), 2)
+}
+
+func TestSchemaRegistryClient_GetSchemaByVersionWithArbitrarySubjectWithoutReferences(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		responsePayload := schemaResponse{
+			Subject:    "test1",
+			Version:    1,
+			Schema:     "payload",
+			ID:         1,
+			References: nil,
+		}
+		response, _ := json.Marshal(responsePayload)
+
+		switch req.URL.String() {
+		case "/subjects/test1/versions/1":
+			// Send response to be tested
+			rw.Write(response)
+		default:
+			require.Fail(t, "unhandled request")
+		}
+
+	}))
+
+	srClient := CreateSchemaRegistryClient(server.URL)
+	srClient.CodecCreationEnabled(false)
+	schema, err := srClient.GetSchemaByVersionWithArbitrarySubject("test1", 1)
+
+	// Test response
+	assert.NoError(t, err)
+	assert.Equal(t, schema.ID(), 1)
+	assert.Nil(t, schema.codec)
+	assert.Equal(t, schema.Schema(), "payload")
+	assert.Equal(t, schema.Version(), 1)
+	assert.Nil(t, schema.References())
+	assert.Equal(t, len(schema.References()), 0)
 }


### PR DESCRIPTION
According to the schema registry API docs, we get a list of references when reading or creating a new schema.

Reference: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--subjects-(string-%20subject)-versions