### PR TITLE
Do not disable cache when fetching a schema

### DIFF
--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -186,16 +186,8 @@ func (client *SchemaRegistryClient) GetSchema(schemaID int) (*Schema, error) {
 // GetLatestSchema gets the schema associated with the given subject.
 // The schema returned contains the last version for that subject.
 func (client *SchemaRegistryClient) GetLatestSchema(subject string, isKey bool) (*Schema, error) {
-
-	// In order to ensure consistency, we need
-	// to temporarily disable caching to force
-	// the retrieval of the latest release from
-	// Schema Registry.
-	cachingEnabled := client.getCachingEnabled()
-	client.CachingEnabled(false)
 	concreteSubject := getConcreteSubject(subject, isKey)
 	schema, err := client.getVersion(concreteSubject, "latest")
-	client.CachingEnabled(cachingEnabled)
 
 	return schema, err
 }
@@ -204,15 +196,7 @@ func (client *SchemaRegistryClient) GetLatestSchema(subject string, isKey bool) 
 // '-value' or '-key' is not appended to the subject
 // The schema returned contains the last version for that subject.
 func (client *SchemaRegistryClient) GetLatestSchemaWithArbitrarySubject(subject string) (*Schema, error) {
-
-	// In order to ensure consistency, we need
-	// to temporarily disable caching to force
-	// the retrieval of the latest release from
-	// Schema Registry.
-	cachingEnabled := client.getCachingEnabled()
-	client.CachingEnabled(false)
 	schema, err := client.getVersion(subject, "latest")
-	client.CachingEnabled(cachingEnabled)
 
 	return schema, err
 }


### PR DESCRIPTION
## Description of the problem

This issue refers to the initial question : https://github.com/riferrei/srclient/issues/47

We are considering using this library in our producers however given the throughput we aim it feels not right to hit the schema registry on every call. 


## Proposed solution

This change aligns the behavior of the caching with the java implementation.
See: https://github.com/confluentinc/schema-registry/blob/8c4385c0f3b14bb5fb1046661f9bb5ff532de2d1/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java#L202

 Who wants to disable caching can do it via the `CacheEnabled(boolean)` method.