### PR TITLE
Remove IsKeys and Arbitrary Functions, Expose Http Client

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -47,22 +47,7 @@ we set this schema as the first version of the subject and store it in memory.
 
 Note that there is no enforcement of schema compatibility, any schema goes for all subjects.
 */
-func (mck MockSchemaRegistryClient) CreateSchema(subject string, schema string, schemaType SchemaType, isKey bool, references ...Reference) (*Schema, error) {
-	concreteSubject := getConcreteSubject(subject, isKey)
-
-	return mck.CreateSchemaWithArbitrarySubject(concreteSubject, schema, schemaType, references...)
-}
-
-/*
-Mock Schema creation and registration. CreateSchema behaves in two possible ways according to the scenario:
-1. The schema being registered is for an already existing `concrete subject`. In that case,
-we increase our schemaID counter and register the schema under that subject in memory.
-2. The schema being registered is for a previously unknown `concrete subject`. In that case,
-we set this schema as the first version of the subject and store it in memory.
-
-Note that there is no enforcement of schema compatibility, any schema goes for all subjects.
-*/
-func (mck MockSchemaRegistryClient) CreateSchemaWithArbitrarySubject(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error) {
+func (mck MockSchemaRegistryClient) CreateSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error) {
 	switch schemaType {
 	case Avro, Json:
 		compiledRegex := regexp.MustCompile(`\r?\n`)
@@ -116,30 +101,14 @@ func (mck MockSchemaRegistryClient) GetSchema(schemaID int) (*Schema, error) {
 }
 
 // Returns the highest ordinal version of a Schema for a given `concrete subject`
-func (mck MockSchemaRegistryClient) GetLatestSchema(subject string, isKey bool) (*Schema, error) {
-	versions, getSchemaVersionErr := mck.GetSchemaVersions(subject, isKey)
+func (mck MockSchemaRegistryClient) GetLatestSchema(subject string) (*Schema, error) {
+	versions, getSchemaVersionErr := mck.GetSchemaVersions(subject)
 	if getSchemaVersionErr != nil {
 		return nil, getSchemaVersionErr
 	}
 
 	latestVersion := versions[len(versions)-1]
-	thisSchema, err := mck.GetSchemaByVersion(subject, latestVersion, isKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return thisSchema, nil
-}
-
-// Returns the highest ordinal version of a Schema for a given `concrete subject`
-func (mck MockSchemaRegistryClient) GetLatestSchemaWithArbitrarySubject(subject string) (*Schema, error) {
-	versions, getSchemaVersionErr := mck.GetSchemaVersionsWithArbitrarySubject(subject)
-	if getSchemaVersionErr != nil {
-		return nil, getSchemaVersionErr
-	}
-
-	latestVersion := versions[len(versions)-1]
-	thisSchema, err := mck.GetSchemaByVersionWithArbitrarySubject(subject, latestVersion)
+	thisSchema, err := mck.GetSchemaByVersion(subject, latestVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -148,27 +117,13 @@ func (mck MockSchemaRegistryClient) GetLatestSchemaWithArbitrarySubject(subject 
 }
 
 // Returns the array of versions this subject has previously registered
-func (mck MockSchemaRegistryClient) GetSchemaVersions(subject string, isKey bool) ([]int, error) {
-	concreteSubject := getConcreteSubject(subject, isKey)
-	versions := mck.allVersions(concreteSubject)
-	return versions, nil
-}
-
-// Returns the array of versions this subject has previously registered
-func (mck MockSchemaRegistryClient) GetSchemaVersionsWithArbitrarySubject(subject string) ([]int, error) {
+func (mck MockSchemaRegistryClient) GetSchemaVersions(subject string) ([]int, error) {
 	versions := mck.allVersions(subject)
 	return versions, nil
 }
 
 // Returns the given Schema according to the passed in subject and version number
-func (mck MockSchemaRegistryClient) GetSchemaByVersion(subject string, version int, isKey bool) (*Schema, error) {
-	concreteSubject := getConcreteSubject(subject, isKey)
-
-	return mck.GetSchemaByVersionWithArbitrarySubject(concreteSubject, version)
-}
-
-// Returns the given Schema according to the passed in subject and version number
-func (mck MockSchemaRegistryClient) GetSchemaByVersionWithArbitrarySubject(subject string, version int) (*Schema, error) {
+func (mck MockSchemaRegistryClient) GetSchemaByVersion(subject string, version int) (*Schema, error) {
 	schema := &Schema{}
 	schemaVersionMap, ok := mck.schemaCache[subject]
 	if !ok {
@@ -231,7 +186,7 @@ func (mck MockSchemaRegistryClient) CodecCreationEnabled(value bool) {
 	// Nothing because codecs do not matter in the inMem storage of schemas
 }
 
-func (mck MockSchemaRegistryClient) IsSchemaCompatible(subject, schema, version string, schemaType SchemaType, isKey bool) (bool, error) {
+func (mck MockSchemaRegistryClient) IsSchemaCompatible(subject, schema, version string, schemaType SchemaType) (bool, error) {
 	return false, errors.New("mock schema registry client can't check for schema compatibility")
 }
 

--- a/mockSchemaRegistryClient_test.go
+++ b/mockSchemaRegistryClient_test.go
@@ -53,15 +53,15 @@ func init() {
 	srClient = CreateMockSchemaRegistryClient("mock://testingUrl")
 
 	// Test Schema and Value Schema creation
-	_, _ = srClient.CreateSchema("test1", schema, Avro, false)
-	_, _ = srClient.CreateSchema("test1", schema, Avro, true)
+	_, _ = srClient.CreateSchema("test1-value", schema, Avro)
+	_, _ = srClient.CreateSchema("test1-key", schema, Avro)
 	// Test version upgrades for key and value and more registration
-	_, _ = srClient.CreateSchema("test1", schema2, Avro, false)
-	_, _ = srClient.CreateSchema("test1", schema2, Avro, true)
+	_, _ = srClient.CreateSchema("test1-value", schema2, Avro)
+	_, _ = srClient.CreateSchema("test1-key", schema2, Avro)
 
 	// Test version upgrades for key and value and more registration (arbitrary subject)
-	_, _ = srClient.CreateSchemaWithArbitrarySubject("test1_arb", schema3, Avro)
-	_, _ = srClient.CreateSchemaWithArbitrarySubject("test1_arb", schema4, Avro)
+	_, _ = srClient.CreateSchema("test1_arb", schema3, Avro)
+	_, _ = srClient.CreateSchema("test1_arb", schema4, Avro)
 }
 
 func TestMockSchemaRegistryClient_CreateSchema(t *testing.T) {
@@ -82,14 +82,6 @@ func TestMockSchemaRegistryClient_CreateSchema(t *testing.T) {
 	schemaReg4, _ := srClient.GetSchema(4)
 	assert.Equal(t, schema2, schemaReg4.schema)
 	assert.Equal(t, 2, schemaReg4.version)
-
-	// Test registering already registered schema
-	_, err := srClient.CreateSchema("test1", schema, Avro, true)
-	assert.EqualError(t, err, "POST \"mock://testingUrl/subjects/test1-key/versions\": Schema already registered with id 2")
-}
-
-func TestMockSchemaRegistryClient_CreateSchema_ArbitrarySubject(t *testing.T) {
-
 	schemaReg5, _ := srClient.GetSchema(5)
 	assert.Equal(t, schema3, schemaReg5.schema)
 	assert.Equal(t, 1, schemaReg5.version)
@@ -98,24 +90,25 @@ func TestMockSchemaRegistryClient_CreateSchema_ArbitrarySubject(t *testing.T) {
 	assert.Equal(t, 2, schemaReg6.version)
 
 	// Test registering already registered schema
-	_, err := srClient.CreateSchemaWithArbitrarySubject("test1_arb", schema3, Avro)
+	_, err := srClient.CreateSchema("test1-key", schema, Avro)
+	assert.EqualError(t, err, "POST \"mock://testingUrl/subjects/test1-key/versions\": Schema already registered with id 2")
+
+	// Test registering already registered schema
+	_, err = srClient.CreateSchema("test1_arb", schema3, Avro)
 	assert.EqualError(t, err, "POST \"mock://testingUrl/subjects/test1_arb/versions\": Schema already registered with id 5")
 }
 
 func TestMockSchemaRegistryClient_GetLatestSchema(t *testing.T) {
 
-	latest, err := srClient.GetLatestSchema("test1", true)
+	latest, err := srClient.GetLatestSchema("test1-key")
 	if err != nil {
 		fmt.Println(err.Error())
 		t.Fail()
 	} else {
 		assert.Equal(t, schema2, latest.schema)
 	}
-}
 
-func TestMockSchemaRegistryClient_GetLatestSchema_ArbitrarySubject(t *testing.T) {
-
-	latest, err := srClient.GetLatestSchemaWithArbitrarySubject("test1_arb")
+	latest, err = srClient.GetLatestSchema("test1_arb")
 	if err != nil {
 		fmt.Println(err.Error())
 		t.Fail()
@@ -125,22 +118,18 @@ func TestMockSchemaRegistryClient_GetLatestSchema_ArbitrarySubject(t *testing.T)
 }
 
 func TestMockSchemaRegistryClient_GetSchemaVersions(t *testing.T) {
-	versions, _ := srClient.GetSchemaVersions("test1", true)
+	versions, _ := srClient.GetSchemaVersions("test1-key")
 	assert.Equal(t, 2, len(versions))
-}
 
-func TestMockSchemaRegistryClient_GetSchemaVersions_ArbitrarySubject(t *testing.T) {
-	versions, _ := srClient.GetSchemaVersionsWithArbitrarySubject("test1_arb")
+	versions, _ = srClient.GetSchemaVersions("test1_arb")
 	assert.Equal(t, 2, len(versions))
 }
 
 func TestMockSchemaRegistryClient_GetSchemaByVersion(t *testing.T) {
-	oldVersion, _ := srClient.GetSchemaByVersion("test1", 1, false)
+	oldVersion, _ := srClient.GetSchemaByVersion("test1-value", 1)
 	assert.Equal(t, schema, oldVersion.schema)
-}
 
-func TestMockSchemaRegistryClient_GetSchemaByVersion_ArbitrarySubject(t *testing.T) {
-	oldVersion, _ := srClient.GetSchemaByVersionWithArbitrarySubject("test1_arb", 1)
+	oldVersion, _ = srClient.GetSchemaByVersion("test1_arb", 1)
 	assert.Equal(t, schema3, oldVersion.schema)
 }
 

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -124,14 +124,19 @@ const (
 // using this client can retrieve data about schemas, which
 // in turn can be used to serialize and deserialize records.
 func CreateSchemaRegistryClient(schemaRegistryURL string) *SchemaRegistryClient {
+	return CreateSchemaRegistryClientWithOptions(schemaRegistryURL, &http.Client{Timeout: 5 * time.Second}, 16)
+}
+
+// CreateSchemaRegistryClientWithOptions provides the ability to pass the http.Client to be used, as well as the semaphoreWeight for concurrent requests
+func CreateSchemaRegistryClientWithOptions(schemaRegistryURL string, client *http.Client, semaphoreWeight int) *SchemaRegistryClient {
 	return &SchemaRegistryClient{
 		schemaRegistryURL:    schemaRegistryURL,
-		httpClient:           &http.Client{Timeout: 5 * time.Second},
+		httpClient:           client,
 		cachingEnabled:       true,
 		codecCreationEnabled: false,
 		idSchemaCache:        make(map[int]*Schema),
 		subjectSchemaCache:   make(map[string]*Schema),
-		sem:                  semaphore.NewWeighted(16),
+		sem:                  semaphore.NewWeighted(int64(semaphoreWeight)),
 	}
 }
 

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -21,181 +21,187 @@ func bodyToString(in io.ReadCloser) string {
 }
 
 func TestSchemaRegistryClient_CreateSchemaWithoutReferences(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		responsePayload := schemaResponse{
-			Subject: "test1",
-			Version: 1,
-			Schema:  "test2",
-			ID:      1,
-		}
-		response, _ := json.Marshal(responsePayload)
 
-		switch req.URL.String() {
-		case "/subjects/test1-value/versions":
-			requestPayload := schemaRequest{
-				Schema:     "test2",
-				SchemaType: Protobuf.String(),
-				References: []Reference{},
+	{
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			responsePayload := schemaResponse{
+				Subject: "test1",
+				Version: 1,
+				Schema:  "test2",
+				ID:      1,
 			}
-			expected, _ := json.Marshal(requestPayload)
-			// Test payload
-			assert.Equal(t, bodyToString(req.Body), string(expected))
-			// Send response to be tested
-			rw.Write(response)
-		case "/subjects/test1-value/versions/latest":
-			// Send response to be tested
-			rw.Write(response)
-		default:
-			assert.Error(t, errors.New("unhandled request"))
-		}
+			response, _ := json.Marshal(responsePayload)
+			switch req.URL.String() {
+			case "/subjects/test1-value/versions":
 
-	}))
-
-	srClient := CreateSchemaRegistryClient(server.URL)
-	srClient.CodecCreationEnabled(false)
-	schema, err := srClient.CreateSchema("test1", "test2", Protobuf, false)
-
-	// Test response
-	assert.NoError(t, err)
-	assert.Equal(t, schema.id, 1)
-	assert.Nil(t, schema.codec)
-	assert.Equal(t, schema.schema, "test2")
-	assert.Equal(t, schema.version, 1)
-}
-
-func TestSchemaRegistryClient_CreateSchemaWithArbitrarySubjectName(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		responsePayload := schemaResponse{
-			Subject: "test1",
-			Version: 1,
-			Schema:  "test2",
-			ID:      1,
-		}
-		response, _ := json.Marshal(responsePayload)
-
-		switch req.URL.String() {
-		case "/subjects/test1/versions":
-			requestPayload := schemaRequest{
-				Schema:     "test2",
-				SchemaType: Avro.String(),
-				References: []Reference{},
+				requestPayload := schemaRequest{
+					Schema:     "test2",
+					SchemaType: Protobuf.String(),
+					References: []Reference{},
+				}
+				expected, _ := json.Marshal(requestPayload)
+				// Test payload
+				assert.Equal(t, bodyToString(req.Body), string(expected))
+				// Send response to be tested
+				rw.Write(response)
+			case "/subjects/test1-value/versions/latest":
+				// Send response to be tested
+				rw.Write(response)
+			default:
+				assert.Error(t, errors.New("unhandled request"))
 			}
-			expected, _ := json.Marshal(requestPayload)
-			// Test payload
-			assert.Equal(t, bodyToString(req.Body), string(expected))
-			// Send response to be tested
-			rw.Write(response)
-		case "/subjects/test1/versions/latest":
-			// Send response to be tested
-			rw.Write(response)
-		default:
-			assert.Error(t, errors.New("unhandled request"))
-		}
 
-	}))
+		}))
 
-	srClient := CreateSchemaRegistryClient(server.URL)
-	srClient.CodecCreationEnabled(false)
-	schema, err := srClient.CreateSchemaWithArbitrarySubject("test1", "test2", Avro)
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		schema, err := srClient.CreateSchema("test1-value", "test2", Protobuf)
 
-	// Test response
-	assert.NoError(t, err)
-	assert.Equal(t, schema.id, 1)
-	assert.Nil(t, schema.codec)
-	assert.Equal(t, schema.schema, "test2")
-	assert.Equal(t, schema.version, 1)
-}
-
-func TestSchemaRegistryClient_GetSchemaByVersionWithArbitrarySubjectWithReferences(t *testing.T) {
-	refs := []Reference{
-		{Name: "name1", Subject: "subject1", Version: 1},
-		{Name: "name2", Subject: "subject2", Version: 2},
+		// Test response
+		assert.NoError(t, err)
+		assert.Equal(t, schema.id, 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.schema, "test2")
+		assert.Equal(t, schema.version, 1)
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		responsePayload := schemaResponse{
+	{
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			responsePayload := schemaResponse{
+				Subject: "test1",
+				Version: 1,
+				Schema:  "test2",
+				ID:      1,
+			}
+			response, _ := json.Marshal(responsePayload)
+
+			switch req.URL.String() {
+			case "/subjects/test1/versions":
+				requestPayload := schemaRequest{
+					Schema:     "test2",
+					SchemaType: Avro.String(),
+					References: []Reference{},
+				}
+				expected, _ := json.Marshal(requestPayload)
+				// Test payload
+				assert.Equal(t, bodyToString(req.Body), string(expected))
+				// Send response to be tested
+				rw.Write(response)
+			case "/subjects/test1/versions/latest":
+				// Send response to be tested
+				rw.Write(response)
+			default:
+				assert.Error(t, errors.New("unhandled request"))
+			}
+
+		}))
+
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		schema, err := srClient.CreateSchema("test1", "test2", Avro)
+
+		// Test response
+		assert.NoError(t, err)
+		assert.Equal(t, schema.id, 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.schema, "test2")
+		assert.Equal(t, schema.version, 1)
+	}
+}
+
+func TestSchemaRegistryClient_GetSchemaByVersionWithReferences(t *testing.T) {
+	{
+		refs := []Reference{
+			{Name: "name1", Subject: "subject1", Version: 1},
+			{Name: "name2", Subject: "subject2", Version: 2},
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			responsePayload := schemaResponse{
+				Subject:    "test1",
+				Version:    1,
+				Schema:     "payload",
+				ID:         1,
+				References: refs,
+			}
+			response, _ := json.Marshal(responsePayload)
+
+			switch req.URL.String() {
+			case "/subjects/test1/versions/1":
+				// Send response to be tested
+				rw.Write(response)
+			default:
+				require.Fail(t, "unhandled request")
+			}
+
+		}))
+
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		schema, err := srClient.GetSchemaByVersion("test1", 1)
+
+		// Test response
+		assert.NoError(t, err)
+		assert.Equal(t, schema.ID(), 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.Schema(), "payload")
+		assert.Equal(t, schema.Version(), 1)
+		assert.Equal(t, schema.References(), refs)
+		assert.Equal(t, len(schema.References()), 2)
+	}
+	{
+		server, call := mockServerWithSchemaResponse(t, "test1", "1", schemaResponse{
 			Subject:    "test1",
 			Version:    1,
 			Schema:     "payload",
 			ID:         1,
-			References: refs,
-		}
-		response, _ := json.Marshal(responsePayload)
+			References: nil,
+		})
 
-		switch req.URL.String() {
-		case "/subjects/test1/versions/1":
-			// Send response to be tested
-			rw.Write(response)
-		default:
-			require.Fail(t, "unhandled request")
-		}
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		schema, err := srClient.GetSchemaByVersion("test1", 1)
 
-	}))
+		// Test response
+		assert.NoError(t, err)
 
-	srClient := CreateSchemaRegistryClient(server.URL)
-	srClient.CodecCreationEnabled(false)
-	schema, err := srClient.GetSchemaByVersionWithArbitrarySubject("test1", 1)
-
-	// Test response
-	assert.NoError(t, err)
-	assert.Equal(t, schema.ID(), 1)
-	assert.Nil(t, schema.codec)
-	assert.Equal(t, schema.Schema(), "payload")
-	assert.Equal(t, schema.Version(), 1)
-	assert.Equal(t, schema.References(), refs)
-	assert.Equal(t, len(schema.References()), 2)
+		assert.Equal(t, 1, *call)
+		assert.Equal(t, schema.ID(), 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.Schema(), "payload")
+		assert.Equal(t, schema.Version(), 1)
+		assert.Nil(t, schema.References())
+		assert.Equal(t, len(schema.References()), 0)
+	}
 }
 
-func TestSchemaRegistryClient_GetSchemaByVersionWithArbitrarySubjectWithoutReferences(t *testing.T) {
-	server, call := mockServerWithSchemaResponse(t,"test1", "1", schemaResponse{
-		Subject:    "test1",
-		Version:    1,
-		Schema:     "payload",
-		ID:         1,
-		References: nil,
-	})
+func TestSchemaRegistryClient_GetSchemaByVersionReturnsValueFromCache(t *testing.T) {
+	{
+		server, call := mockServerWithSchemaResponse(t, "test1", "1", schemaResponse{
+			Subject:    "test1",
+			Version:    1,
+			Schema:     "payload",
+			ID:         1,
+			References: nil,
+		})
 
-	srClient := CreateSchemaRegistryClient(server.URL)
-	srClient.CodecCreationEnabled(false)
-	schema, err := srClient.GetSchemaByVersionWithArbitrarySubject("test1", 1)
+		srClient := CreateSchemaRegistryClient(server.URL)
+		schema1, err := srClient.GetSchemaByVersion("test1", 1)
 
-	// Test response
-	assert.NoError(t, err)
+		// Test response
+		assert.NoError(t, err)
 
-	assert.Equal(t, 1, *call)
-	assert.Equal(t, schema.ID(), 1)
-	assert.Nil(t, schema.codec)
-	assert.Equal(t, schema.Schema(), "payload")
-	assert.Equal(t, schema.Version(), 1)
-	assert.Nil(t, schema.References())
-	assert.Equal(t, len(schema.References()), 0)
-}
+		// When called twice
+		schema2, err := srClient.GetSchemaByVersion("test1", 1)
 
-func TestSchemaRegistryClient_GetSchemaByVersionWithArbitrarySubjectReturnsValueFromCache(t *testing.T) {
-	server, call := mockServerWithSchemaResponse(t,"test1", "1", schemaResponse{
-		Subject:    "test1",
-		Version:    1,
-		Schema:     "payload",
-		ID:         1,
-		References: nil,
-	})
-
-	srClient := CreateSchemaRegistryClient(server.URL)
-	schema1, err := srClient.GetSchemaByVersionWithArbitrarySubject("test1", 1)
-
-	// Test response
-	assert.NoError(t, err)
-
-	// When called twice
-	schema2, err := srClient.GetSchemaByVersionWithArbitrarySubject("test1", 1)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 1, *call)
-	assert.Equal(t, schema1, schema2)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, *call)
+		assert.Equal(t, schema1, schema2)
+	}
 }
 
 func TestSchemaRegistryClient_GetLatestSchemaReturnsValueFromCache(t *testing.T) {
-	server, call := mockServerWithSchemaResponse(t,"test1-value", "latest", schemaResponse{
+	server, call := mockServerWithSchemaResponse(t, "test1-value", "latest", schemaResponse{
 		Subject:    "test1",
 		Version:    1,
 		Schema:     "payload",
@@ -204,19 +210,18 @@ func TestSchemaRegistryClient_GetLatestSchemaReturnsValueFromCache(t *testing.T)
 	})
 
 	srClient := CreateSchemaRegistryClient(server.URL)
-	schema1, err := srClient.GetLatestSchema("test1", false)
+	schema1, err := srClient.GetLatestSchema("test1-value")
 
 	// Test response
 	assert.NoError(t, err)
 
 	// When called twice
-	schema2, err := srClient.GetLatestSchema("test1", false)
+	schema2, err := srClient.GetLatestSchema("test1-value")
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, *call)
 	assert.Equal(t, schema1, schema2)
 }
-
 
 func mockServerWithSchemaResponse(t *testing.T, subject string, version string, schemaResponse schemaResponse) (*httptest.Server, *int) {
 	var count int


### PR DESCRIPTION
As per #31 and a short discussion on #47, this PR removes all IsKey arguments therefore making the arbitrary functions default and also exposes the http.Client for possible configurations for the developers.

Introduces breaking changes.