### PR TITLE
Implement ChangeSubjectCompatibilityLevel, GetGlobalCompatibilityLevel and GetCompatibilityLevel

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -167,6 +167,10 @@ func (mck MockSchemaRegistryClient) DeleteSubject(subject string, _ bool) error 
 	return nil
 }
 
+func (mck MockSchemaRegistryClient) ChangeSubjectCompatibilityLevel(subject string, compatibility CompatibilityLevel) (*CompatibilityLevel, error) {
+	return nil, errors.New("mock schema registry client can't change subject compatibility level")
+}
+
 func (mck MockSchemaRegistryClient) GetGlobalCompatibilityLevel() (*CompatibilityLevel, error) {
 	return nil, errors.New("mock schema registry client can't return global compatibility level")
 }


### PR DESCRIPTION
I have implemented the following two endpoints to be able to read the compatibility levels.
* https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--config
* https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--config-(string-%20subject)
* https://docs.confluent.io/platform/current/schema-registry/develop/api.html#put--config-(string-%20subject)