### PR TITLE
Added LookupSchema method to SchemaRegistryClient

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -85,6 +85,20 @@ func (mck MockSchemaRegistryClient) CreateSchema(subject string, schema string, 
 	}
 }
 
+func (mck MockSchemaRegistryClient) LookupSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error) {
+	switch schemaType {
+	case Avro, Json:
+		compiledRegex := regexp.MustCompile(`\r?\n`)
+		schema = compiledRegex.ReplaceAllString(schema, " ")
+	case Protobuf:
+		break
+	default:
+		return nil, fmt.Errorf("invalid schema type. valid values are Avro, Json, or Protobuf")
+	}
+
+	return nil, nil
+}
+
 // Returns a Schema for the given ID
 func (mck MockSchemaRegistryClient) GetSchema(schemaID int) (*Schema, error) {
 	posErr := url.Error{

--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -85,20 +85,6 @@ func (mck MockSchemaRegistryClient) CreateSchema(subject string, schema string, 
 	}
 }
 
-func (mck MockSchemaRegistryClient) LookupSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error) {
-	switch schemaType {
-	case Avro, Json:
-		compiledRegex := regexp.MustCompile(`\r?\n`)
-		schema = compiledRegex.ReplaceAllString(schema, " ")
-	case Protobuf:
-		break
-	default:
-		return nil, fmt.Errorf("invalid schema type. valid values are Avro, Json, or Protobuf")
-	}
-
-	return nil, nil
-}
-
 // Returns a Schema for the given ID
 func (mck MockSchemaRegistryClient) GetSchema(schemaID int) (*Schema, error) {
 	posErr := url.Error{
@@ -219,6 +205,10 @@ func (mck MockSchemaRegistryClient) CodecCreationEnabled(value bool) {
 
 func (mck MockSchemaRegistryClient) IsSchemaCompatible(subject, schema, version string, schemaType SchemaType) (bool, error) {
 	return false, errors.New("mock schema registry client can't check for schema compatibility")
+}
+
+func (mck MockSchemaRegistryClient) LookupSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error) {
+	return nil, errors.New("mock schema registry client can't lookup schema")
 }
 
 /*

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -430,7 +430,7 @@ func (client *SchemaRegistryClient) LookupSchema(subject string, schema string, 
 	}
 
 	var codec *goavro.Codec
-	if client.getCodecCreationEnabled() {
+	if client.getCodecCreationEnabled() && schemaType == Avro {
 		codec, err = goavro.NewCodec(schemaResp.Schema)
 		if err != nil {
 			return nil, err

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -30,6 +30,7 @@ type ISchemaRegistryClient interface {
 	GetSchemaVersions(subject string) ([]int, error)
 	GetSchemaByVersion(subject string, version int) (*Schema, error)
 	CreateSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error)
+	LookupSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error)
 	ChangeSubjectCompatibilityLevel(subject string, compatibility CompatibilityLevel) (*CompatibilityLevel, error)
 	DeleteSubject(subject string, permanent bool) error
 	SetCredentials(username string, password string)
@@ -143,6 +144,7 @@ type configChangeResponse configChangeRequest
 
 const (
 	schemaByID       = "/schemas/ids/%d"
+	subjectBySubject = "/subjects/%s"
 	subjectVersions  = "/subjects/%s/versions"
 	subjectByVersion = "/subjects/%s/versions/%s"
 	subjects         = "/subjects"
@@ -392,6 +394,73 @@ func (client *SchemaRegistryClient) CreateSchema(subject string, schema string,
 	}
 
 	return newSchema, nil
+}
+
+// LookupSchema looks up the schema by subject and schema string. If it finds the schema it returns it with all its associated information.
+func (client *SchemaRegistryClient) LookupSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error) {
+	switch schemaType {
+	case Avro, Json:
+		compiledRegex := regexp.MustCompile(`\r?\n`)
+		schema = compiledRegex.ReplaceAllString(schema, " ")
+	case Protobuf:
+		break
+	default:
+		return nil, fmt.Errorf("invalid schema type. valid values are Avro, Json, or Protobuf")
+	}
+
+	if references == nil {
+		references = make([]Reference, 0)
+	}
+
+	schemaReq := schemaRequest{Schema: schema, SchemaType: schemaType.String(), References: references}
+	schemaBytes, err := json.Marshal(schemaReq)
+	if err != nil {
+		return nil, err
+	}
+	payload := bytes.NewBuffer(schemaBytes)
+	resp, err := client.httpRequest("POST", fmt.Sprintf(subjectBySubject, subject), payload)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaResp := new(schemaResponse)
+	err = json.Unmarshal(resp, &schemaResp)
+	if err != nil {
+		return nil, err
+	}
+
+	var codec *goavro.Codec
+	if client.getCodecCreationEnabled() {
+		codec, err = goavro.NewCodec(schemaResp.Schema)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var gotSchema = &Schema{
+		id:         schemaResp.ID,
+		schema:     schemaResp.Schema,
+		version:    schemaResp.Version,
+		references: schemaResp.References,
+		codec:      codec,
+	}
+
+	if client.getCachingEnabled() {
+
+		// Update the subject-2-schema cache
+		cacheKey := cacheKey(subject,
+			strconv.Itoa(gotSchema.version))
+		client.subjectSchemaCacheLock.Lock()
+		client.subjectSchemaCache[cacheKey] = gotSchema
+		client.subjectSchemaCacheLock.Unlock()
+
+		// Update the id-2-schema cache
+		client.idSchemaCacheLock.Lock()
+		client.idSchemaCache[gotSchema.id] = gotSchema
+		client.idSchemaCacheLock.Unlock()
+
+	}
+
+	return gotSchema, nil
 }
 
 // IsSchemaCompatible checks if the given schema is compatible with the given subject and version

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -190,6 +190,45 @@ func TestSchemaRegistryClient_LookupSchemaWithoutReferences(t *testing.T) {
 		assert.Equal(t, schema.schema, "test2")
 		assert.Equal(t, schema.version, 1)
 	}
+
+	{
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			var errorResp struct {
+				ErrorCode int    `json:"error_code"`
+				Message   string `json:"message"`
+			}
+			errorResp.ErrorCode = 40401
+			errorResp.Message = "Subject 'test1' not found"
+
+			response, _ := json.Marshal(errorResp)
+			switch req.URL.String() {
+			case "/subjects/test1-value":
+
+				requestPayload := schemaRequest{
+					Schema:     "test2",
+					SchemaType: Avro.String(),
+					References: []Reference{},
+				}
+				expected, _ := json.Marshal(requestPayload)
+				// Test payload
+				assert.Equal(t, bodyToString(req.Body), string(expected))
+				// Send error response to simulate the schema not being found
+				rw.WriteHeader(http.StatusNotFound)
+				rw.Write(response)
+			default:
+				assert.Error(t, errors.New("unhandled request"))
+			}
+
+		}))
+
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		_, err := srClient.LookupSchema("test1-value", "test2", Avro)
+
+		// Test response
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "404 Not Found: Subject 'test1' not found")
+	}
 }
 
 func TestSchemaRegistryClient_GetSchemaByVersionWithReferences(t *testing.T) {

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -109,6 +109,50 @@ func TestSchemaRegistryClient_CreateSchemaWithoutReferences(t *testing.T) {
 	}
 }
 
+func TestSchemaRegistryClient_LookupSchemaWithoutReferences(t *testing.T) {
+
+	{
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			responsePayload := schemaResponse{
+				Subject: "test1",
+				Version: 1,
+				Schema:  "test2",
+				ID:      1,
+			}
+			response, _ := json.Marshal(responsePayload)
+			switch req.URL.String() {
+			case "/subjects/test1-value":
+
+				requestPayload := schemaRequest{
+					Schema:     "test2",
+					SchemaType: Protobuf.String(),
+					References: []Reference{},
+				}
+				expected, _ := json.Marshal(requestPayload)
+				// Test payload
+				assert.Equal(t, bodyToString(req.Body), string(expected))
+				// Send response to be tested
+				rw.Write(response)
+			default:
+				assert.Error(t, errors.New("unhandled request"))
+			}
+
+		}))
+
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		schema, err := srClient.LookupSchema("test1-value", "test2", Protobuf)
+
+		// Test response
+		assert.NoError(t, err)
+		assert.Equal(t, schema.id, 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.schema, "test2")
+		assert.Equal(t, schema.version, 1)
+	}
+
+}
+
 func TestSchemaRegistryClient_GetSchemaByVersionWithReferences(t *testing.T) {
 	{
 		refs := []Reference{


### PR DESCRIPTION
The confluent schema registry API has this endpoint:
```POST /subjects/(string: subject)```

https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--subjects-(string-%20subject)
This is to check if a schema has already been registered under a specific subject.
This method is important because it is the schema lookup method that the serialiser is supposed to use if both "auto.register.schemas" and "use.latest.version" are set to false.

I also added test cases.