### PR TITLE
Add reset cache mechanism to SchemaRegistryClient

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -199,6 +199,10 @@ func (mck MockSchemaRegistryClient) CachingEnabled(value bool) {
 	// Nothing because caching is always enabled, duh
 }
 
+func (mck MockSchemaRegistryClient) ResetCache() {
+	// Nothing because there is no lock for cache
+}
+
 func (mck MockSchemaRegistryClient) CodecCreationEnabled(value bool) {
 	// Nothing because codecs do not matter in the inMem storage of schemas
 }


### PR DESCRIPTION
After caching, the schema in the cache does not change. If the latest schema changes on the schema registry, the new schema will not be retrieved. This reset mechanism allows retrieving the most updated version of the schema without the need to exit from application.

The cache could be reset periodically to retrieve the most updated version.