### PR TITLE
Omit references if nil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/riferrei/srclient
+module github.com/arnaldur/srclient
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/arnaldur/srclient
+module github.com/riferrei/srclient
 
 go 1.12
 

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -364,10 +364,6 @@ func (client *SchemaRegistryClient) CreateSchema(subject string, schema string,
 		return nil, fmt.Errorf("invalid schema type. valid values are Avro, Json, or Protobuf")
 	}
 
-	// if references == nil {
-	// 	references = make([]Reference, 0)
-	// }
-
 	schemaReq := schemaRequest{Schema: schema, SchemaType: schemaType.String(), References: references}
 	schemaBytes, err := json.Marshal(schemaReq)
 	if err != nil {
@@ -425,10 +421,6 @@ func (client *SchemaRegistryClient) LookupSchema(subject string, schema string, 
 		break
 	default:
 		return nil, fmt.Errorf("invalid schema type. valid values are Avro, Json, or Protobuf")
-	}
-
-	if references == nil {
-		references = make([]Reference, 0)
 	}
 
 	schemaReq := schemaRequest{Schema: schema, SchemaType: schemaType.String(), References: references}

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -122,7 +122,7 @@ type credentials struct {
 type schemaRequest struct {
 	Schema     string      `json:"schema"`
 	SchemaType string      `json:"schemaType"`
-	References []Reference `json:"references"`
+	References []Reference `json:"references,omitempty"`
 }
 
 type schemaResponse struct {
@@ -131,7 +131,7 @@ type schemaResponse struct {
 	Schema     string      `json:"schema"`
 	SchemaType *SchemaType `json:"schemaType"`
 	ID         int         `json:"id"`
-	References []Reference `json:"references"`
+	References []Reference `json:"references,omitempty"`
 }
 
 type isCompatibleResponse struct {
@@ -364,9 +364,9 @@ func (client *SchemaRegistryClient) CreateSchema(subject string, schema string,
 		return nil, fmt.Errorf("invalid schema type. valid values are Avro, Json, or Protobuf")
 	}
 
-	if references == nil {
-		references = make([]Reference, 0)
-	}
+	// if references == nil {
+	// 	references = make([]Reference, 0)
+	// }
 
 	schemaReq := schemaRequest{Schema: schema, SchemaType: schemaType.String(), References: references}
 	schemaBytes, err := json.Marshal(schemaReq)

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -111,6 +111,149 @@ func TestSchemaRegistryClient_CreateSchemaWithoutReferences(t *testing.T) {
 	}
 }
 
+func TestSchemaRegistryClient_CreateSchemaOmitNilReferences(t *testing.T) {
+	// OmitNilReferences=true with references
+	{
+		refs := []Reference{{Name: "testname", Subject: "testsubject", Version: 1}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			responsePayload := schemaResponse{
+				Subject:    "test1",
+				Version:    1,
+				Schema:     "test2",
+				ID:         1,
+				References: refs,
+			}
+			response, _ := json.Marshal(responsePayload)
+			switch req.URL.String() {
+			case "/subjects/test1-value/versions":
+
+				requestPayload := schemaRequestKarapace{
+					Schema:     "test2",
+					SchemaType: Protobuf.String(),
+					References: refs,
+				}
+				expected, _ := json.Marshal(requestPayload)
+				// Test payload
+				assert.Equal(t, bodyToString(req.Body), string(expected))
+				// Send response to be tested
+				rw.Write(response)
+			case "/subjects/test1-value/versions/latest":
+				// Send response to be tested
+				rw.Write(response)
+			default:
+				assert.Error(t, errors.New("unhandled request"))
+			}
+
+		}))
+
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		srClient.OmitNilReferences(true)
+		schema, err := srClient.CreateSchema("test1-value", "test2", Protobuf, refs...)
+
+		// Test response
+		assert.NoError(t, err)
+		assert.Equal(t, schema.id, 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.schema, "test2")
+		assert.Equal(t, schema.version, 1)
+		assert.Equal(t, schema.references, refs)
+	}
+
+	// OmitNilReferences=false without references
+	{
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			responsePayload := schemaResponse{
+				Subject: "test1",
+				Version: 1,
+				Schema:  "test2",
+				ID:      1,
+			}
+			response, _ := json.Marshal(responsePayload)
+
+			switch req.URL.String() {
+			case "/subjects/test1/versions":
+				requestPayload := schemaRequest{
+					Schema:     "test2",
+					SchemaType: Avro.String(),
+					References: []Reference{},
+				}
+				expected, _ := json.Marshal(requestPayload)
+				// Test payload
+				bodyStr := bodyToString(req.Body)
+				assert.Equal(t, bodyStr, string(expected))
+				assert.Contains(t, bodyStr, `"references":`)
+				// Send response to be tested
+				rw.Write(response)
+			case "/subjects/test1/versions/latest":
+				// Send response to be tested
+				rw.Write(response)
+			default:
+				assert.Error(t, errors.New("unhandled request"))
+			}
+
+		}))
+
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		schema, err := srClient.CreateSchema("test1", "test2", Avro)
+
+		// Test response
+		assert.NoError(t, err)
+		assert.Equal(t, schema.id, 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.schema, "test2")
+		assert.Equal(t, schema.version, 1)
+	}
+
+	// OmitNilReferences=true without references
+	{
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			responsePayload := schemaResponse{
+				Subject: "test1",
+				Version: 1,
+				Schema:  "test2",
+				ID:      1,
+			}
+			response, _ := json.Marshal(responsePayload)
+
+			switch req.URL.String() {
+			case "/subjects/test1/versions":
+				requestPayload := schemaRequestKarapace{
+					Schema:     "test2",
+					SchemaType: Avro.String(),
+				}
+				expected, _ := json.Marshal(requestPayload)
+				// Test payload
+				bodyStr := bodyToString(req.Body)
+				assert.Equal(t, bodyStr, string(expected))
+				assert.NotContains(t, bodyStr, `"references":`)
+				// Send response to be tested
+				rw.Write(response)
+			case "/subjects/test1/versions/latest":
+				// Send response to be tested
+				rw.Write(response)
+			default:
+				assert.Error(t, errors.New("unhandled request"))
+			}
+
+		}))
+
+		srClient := CreateSchemaRegistryClient(server.URL)
+		srClient.CodecCreationEnabled(false)
+		srClient.OmitNilReferences(true)
+		schema, err := srClient.CreateSchema("test1", "test2", Avro)
+
+		// Test response
+		assert.NoError(t, err)
+		assert.Equal(t, schema.id, 1)
+		assert.Nil(t, schema.codec)
+		assert.Equal(t, schema.schema, "test2")
+		assert.Equal(t, schema.version, 1)
+	}
+}
+
 func TestSchemaRegistryClient_LookupSchemaWithoutReferences(t *testing.T) {
 	var errorCode int
 	var errorMessage string


### PR DESCRIPTION
Rationale is that karapace fails if references is set, even if empty: "Unrecognized field: references"

In order to keep srclient compatible I suggest omitting References if nil.

https://github.com/aiven/karapace/issues/195

note, not tested with other registries.