### PR TITLE
Delete subject by version

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -174,6 +174,32 @@ func (mck MockSchemaRegistryClient) DeleteSubject(subject string, _ bool) error 
 	return nil
 }
 
+// DeleteSubjectByVersion removes given subject's version from cache
+func (mck MockSchemaRegistryClient) DeleteSubjectByVersion(subject string, version int, _ bool) error {
+	_, ok := mck.schemaCache[subject]
+	if !ok {
+		posErr := url.Error{
+			Op:  "DELETE",
+			URL: mck.schemaRegistryURL + fmt.Sprintf("/subjects/%s/versions/%d", subject, version),
+			Err: errors.New("Subject Not found"),
+		}
+		return &posErr
+	}
+	for schema, id := range mck.schemaCache[subject] {
+		if id == version {
+			delete(mck.schemaCache[subject], schema)
+			return nil
+		}
+	}
+
+	posErr := url.Error{
+		Op:  "GET",
+		URL: mck.schemaRegistryURL + fmt.Sprintf("/subjects/%s/versions/%d", subject, version),
+		Err: errors.New("Version Not found"),
+	}
+	return &posErr
+}
+
 func (mck MockSchemaRegistryClient) ChangeSubjectCompatibilityLevel(subject string, compatibility CompatibilityLevel) (*CompatibilityLevel, error) {
 	return nil, errors.New("mock schema registry client can't change subject compatibility level")
 }

--- a/mockSchemaRegistryClient_test.go
+++ b/mockSchemaRegistryClient_test.go
@@ -147,3 +147,11 @@ func TestMockSchemaRegistryClient_GetSubjects(t *testing.T) {
 	sort.Strings(allSubjects)
 	assert.Equal(t, allSubjects, []string{"test1-key", "test1-value", "test1_arb"})
 }
+
+func TestMockSchemaRegistryClient_DeleteSubjectByVersion(t *testing.T) {
+	originalCount, _ := srClient.GetSchemaVersions("test1-value")
+	err := srClient.DeleteSubjectByVersion("test1-value", 1, true)
+	assert.NoError(t, err)
+	newCount, _ := srClient.GetSchemaVersions("test1-value")
+	assert.Equal(t, len(originalCount)-1, len(newCount))
+}

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -35,6 +35,7 @@ type ISchemaRegistryClient interface {
 	LookupSchema(subject string, schema string, schemaType SchemaType, references ...Reference) (*Schema, error)
 	ChangeSubjectCompatibilityLevel(subject string, compatibility CompatibilityLevel) (*CompatibilityLevel, error)
 	DeleteSubject(subject string, permanent bool) error
+	DeleteSubjectByVersion(subject string, version int, permanent bool) error
 	SetCredentials(username string, password string)
 	SetTimeout(timeout time.Duration)
 	CachingEnabled(value bool)
@@ -511,6 +512,19 @@ func (client *SchemaRegistryClient) IsSchemaCompatible(subject, schema, version 
 // DeleteSubject deletes
 func (client *SchemaRegistryClient) DeleteSubject(subject string, permanent bool) error {
 	uri := "/subjects/" + subject
+	_, err := client.httpRequest("DELETE", uri, nil)
+	if err != nil || !permanent {
+		return err
+	}
+
+	uri += "?permanent=true"
+	_, err = client.httpRequest("DELETE", uri, nil)
+	return err
+}
+
+// DeleteSubjectByVersion deletes the version of the scheme
+func (client *SchemaRegistryClient) DeleteSubjectByVersion(subject string, version int, permanent bool) error {
+	uri := fmt.Sprintf(subjectByVersion, subject, strconv.Itoa(version))
 	_, err := client.httpRequest("DELETE", uri, nil)
 	if err != nil || !permanent {
 		return err


### PR DESCRIPTION
The ability to remove specific version of the scheme is added according to [https://docs.confluent.io/platform/current/schema-registry/develop/api.html#delete--subjects-(string-%20subject)-versions-(versionId-%20version)](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#delete--subjects-(string-%20subject)-versions-(versionId-%20version)) .

Can be useful for rolling back releases. 

Please review.