### PR TITLE
add references to IsSchemaCompatible check

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -256,7 +256,7 @@ func (mck *MockSchemaRegistryClient) CodecCreationEnabled(bool) {
 }
 
 // IsSchemaCompatible is not implemented
-func (mck *MockSchemaRegistryClient) IsSchemaCompatible(string, string, string, SchemaType) (bool, error) {
+func (mck *MockSchemaRegistryClient) IsSchemaCompatible(string, string, string, SchemaType, ...Reference) (bool, error) {
 	return false, errNotImplemented
 }
 

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -43,7 +43,7 @@ type ISchemaRegistryClient interface {
 	CachingEnabled(value bool)
 	ResetCache()
 	CodecCreationEnabled(value bool)
-	IsSchemaCompatible(subject, schema, version string, schemaType SchemaType) (bool, error)
+	IsSchemaCompatible(subject, schema, version string, schemaType SchemaType, references ...Reference) (bool, error)
 }
 
 // SchemaRegistryClient allows interactions with
@@ -490,8 +490,12 @@ func (client *SchemaRegistryClient) LookupSchema(subject string, schema string, 
 
 // IsSchemaCompatible checks if the given schema is compatible with the given subject and version
 // valid versions are versionID and "latest"
-func (client *SchemaRegistryClient) IsSchemaCompatible(subject, schema, version string, schemaType SchemaType) (bool, error) {
-	schemaReq := schemaRequest{Schema: schema, SchemaType: schemaType.String(), References: make([]Reference, 0)}
+func (client *SchemaRegistryClient) IsSchemaCompatible(subject, schema, version string, schemaType SchemaType, references ...Reference) (bool, error) {
+	if references == nil {
+		references = make([]Reference, 0)
+	}
+
+	schemaReq := schemaRequest{Schema: schema, SchemaType: schemaType.String(), References: references}
 	schemaReqBytes, err := json.Marshal(schemaReq)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
The schema registry REST API allows you to specify references when doing [compatibility checks](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#sr-api-compatibility)
If you have a schema with references the current compatibility check without references will fail. This PR is adding in support for references for compatibility in the same way that it is supported for the other operations.