### PR TITLE
Only include schemaType and References when needed

### DIFF
--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -77,6 +77,8 @@ const (
 )
 
 func (s SchemaType) String() string {
+	// Avro is the default schemaType.
+	// Returning "" omits schemaType from the schemaRequest JSON for compatibility with older API versions.
 	if s == Avro {
 		return ""
 	}

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -77,6 +77,10 @@ const (
 )
 
 func (s SchemaType) String() string {
+	if s == Avro {
+		return ""
+	}
+
 	return string(s)
 }
 
@@ -130,8 +134,8 @@ type credentials struct {
 
 type schemaRequest struct {
 	Schema     string      `json:"schema"`
-	SchemaType string      `json:"schemaType"`
-	References []Reference `json:"references"`
+	SchemaType string      `json:"schemaType,omitempty"`
+	References []Reference `json:"references,omitempty"`
 }
 
 type schemaResponse struct {

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -603,6 +603,62 @@ func TestNewSchema(t *testing.T) {
 	}
 }
 
+func TestSchemaRequestMarshal(t *testing.T) {
+	tests := []struct{
+		schema string
+		schemaType SchemaType
+		references []Reference
+		expected string
+	}{
+		{
+			schema: `test2`,
+			schemaType: Avro,
+			expected: `{"schema":"test2"}`,
+		},
+		{
+			schema: `test2`,
+			schemaType: Protobuf,
+			expected: `{"schema":"test2","schemaType":"PROTOBUF"}`,
+		},
+		{
+			schema: `test2`,
+			schemaType: Json,
+			expected: `{"schema":"test2","schemaType":"JSON"}`,
+		},
+		{
+			schema: `test2`,
+			schemaType: Avro,
+			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
+			expected: `{"schema":"test2","references":[{"name":"name1","subject":"subject1","version":1}]}`,
+		},
+		{
+			schema: `test2`,
+			schemaType: Protobuf,
+			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
+			expected: `{"schema":"test2","schemaType":"PROTOBUF","references":[{"name":"name1","subject":"subject1","version":1}]}`,
+		},
+		{
+			schema: `test2`,
+			schemaType: Json,
+			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
+			expected: `{"schema":"test2","schemaType":"JSON","references":[{"name":"name1","subject":"subject1","version":1}]}`,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			schemaReq := schemaRequest{
+				Schema: test.schema,
+				SchemaType: test.schemaType.String(),
+				References: test.references,
+			}
+			actual, err := json.Marshal(schemaReq)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, string(actual))
+		})
+	}
+}
+
 func mockServerFromSubjectVersionPairWithSchemaResponse(t *testing.T, subject, version string, schemaResponse schemaResponse) (*httptest.Server, *int) {
 	return mockServerWithSchemaResponse(t, fmt.Sprintf("/subjects/%s/versions/%s", subject, version), schemaResponse)
 }

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -604,40 +604,58 @@ func TestNewSchema(t *testing.T) {
 }
 
 func TestSchemaRequestMarshal(t *testing.T) {
-	tests := []struct{
+	tests := map[string]struct{
 		schema string
 		schemaType SchemaType
 		references []Reference
 		expected string
 	}{
-		{
+		"avro": {
 			schema: `test2`,
 			schemaType: Avro,
 			expected: `{"schema":"test2"}`,
 		},
-		{
+		"protobuf": {
 			schema: `test2`,
 			schemaType: Protobuf,
 			expected: `{"schema":"test2","schemaType":"PROTOBUF"}`,
 		},
-		{
+		"json": {
 			schema: `test2`,
 			schemaType: Json,
 			expected: `{"schema":"test2","schemaType":"JSON"}`,
 		},
-		{
+		"avro-empty-ref": {
+			schema: `test2`,
+			schemaType: Avro,
+			references: make([]Reference, 0),
+			expected: `{"schema":"test2"}`,
+		},
+		"protobuf-empty-ref": {
+			schema: `test2`,
+			schemaType: Protobuf,
+			references: make([]Reference, 0),
+			expected: `{"schema":"test2","schemaType":"PROTOBUF"}`,
+		},
+		"json-empty-ref": {
+			schema: `test2`,
+			schemaType: Json,
+			references: make([]Reference, 0),
+			expected: `{"schema":"test2","schemaType":"JSON"}`,
+		},
+		"avro-ref": {
 			schema: `test2`,
 			schemaType: Avro,
 			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
 			expected: `{"schema":"test2","references":[{"name":"name1","subject":"subject1","version":1}]}`,
 		},
-		{
+		"protobuf-ref": {
 			schema: `test2`,
 			schemaType: Protobuf,
 			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
 			expected: `{"schema":"test2","schemaType":"PROTOBUF","references":[{"name":"name1","subject":"subject1","version":1}]}`,
 		},
-		{
+		"json-ref": {
 			schema: `test2`,
 			schemaType: Json,
 			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
@@ -645,16 +663,16 @@ func TestSchemaRequestMarshal(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	for name, testData := range tests {
+		t.Run(name, func(t *testing.T) {
 			schemaReq := schemaRequest{
-				Schema: test.schema,
-				SchemaType: test.schemaType.String(),
-				References: test.references,
+				Schema: testData.schema,
+				SchemaType: testData.schemaType.String(),
+				References: testData.references,
 			}
 			actual, err := json.Marshal(schemaReq)
 			assert.NoError(t, err)
-			assert.Equal(t, test.expected, string(actual))
+			assert.Equal(t, testData.expected, string(actual))
 		})
 	}
 }


### PR DESCRIPTION
Older versions of the Confluent Schema Registry API don't support fields `schemaType` or `References`. Right now, this package always includes these in requests, even if they aren't being used. Since these fields were added to the API, the documentation has stated that they are optional fields. And it's documented that `schemaType` is always assumed to be Avro when it isn't specified. 

This PR ensures that these fields are only included in the request when they're not empty. And it does this with minimal changes to the package.

I need this behavior in order to use this package for my use case. And I've found a few previous issues that had problems that this PR would address:
https://github.com/riferrei/srclient/issues/11 https://github.com/riferrei/srclient/issues/19 https://github.com/riferrei/srclient/issues/21

In addition to the unit tests added in this PR, I've also tested these changes with integration tests specific to my use case.

Please feel free to mention any questions or concerns.