### PR TITLE
Remove else statement that causes schemas to not be set correctly

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -76,7 +76,7 @@ func (mck *MockSchemaRegistryClient) SetSchema(id int, subject string, schema st
 
 	resultFromSchemaCache, ok := mck.schemaCache[subject]
 	if !ok {
-		return mck.generateVersion(id, subject, schema, schemaType, version), nil
+		return mck.generateVersion(id, subject, schema, schemaType, version)
 	}
 
 	// Verify if it's not the same schema as an existing version
@@ -91,7 +91,7 @@ func (mck *MockSchemaRegistryClient) SetSchema(id int, subject string, schema st
 		}
 	}
 
-	return mck.generateVersion(id, subject, schema, schemaType, version), nil
+	return mck.generateVersion(id, subject, schema, schemaType, version)
 }
 
 // GetSchema Returns a Schema for the given ID
@@ -275,7 +275,7 @@ qualify for key/value subjects, it expects to have a `concrete subject` passed o
 */
 
 // generateVersion the next version of the schema for the given subject, givenVersion can be set to -1 to generate one.
-func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, schema string, schemaType SchemaType, givenVersion int) *Schema {
+func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, schema string, schemaType SchemaType, givenVersion int) (*Schema, error) {
 	versions := mck.allVersions(subject)
 	schemaVersionMap := map[int]*Schema{}
 	currentVersion := 1
@@ -292,7 +292,10 @@ func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, sch
 	}
 
 	// Add a codec, required otherwise Codec() panics
-	codec, _ := goavro.NewCodec(schema)
+	codec, err := goavro.NewCodec(schema)
+	if err != nil {
+		return nil, err
+	}
 
 	schemaToRegister := &Schema{
 		id:         id,
@@ -306,7 +309,7 @@ func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, sch
 	mck.schemaCache[subject] = schemaVersionMap
 	mck.idCache[schemaToRegister.id] = schemaToRegister
 
-	return schemaToRegister
+	return schemaToRegister, nil
 }
 
 // allVersions returns all versions for a given subject, assumes it exists

--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -291,7 +291,7 @@ func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, sch
 		}
 	}
 
-	// Add a codec, required otherwise Codec() panics
+	// Add a codec, required otherwise Codec() panics and the mock registry is unusable
 	codec, err := goavro.NewCodec(schema)
 	if err != nil {
 		return nil, err

--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -27,11 +27,11 @@ type MockSchemaRegistryClient struct {
 	// schemaRegistryURL is used to form errors
 	schemaRegistryURL string
 
-	// schemaCache is a map of subject to a map of versions to the actual schema
-	schemaCache map[string]map[int]*Schema
+	// schemaVersions is a map of subject to a map of versions to the actual schema
+	schemaVersions map[string]map[int]*Schema
 
-	// idCache is a map of schema ID to the actual schema
-	idCache map[int]*Schema
+	// schemaIDs is a map of schema ID to the actual schema
+	schemaIDs map[int]*Schema
 
 	// idCounter is used to generate unique IDs for each schema
 	idCounter int
@@ -41,8 +41,8 @@ type MockSchemaRegistryClient struct {
 func CreateMockSchemaRegistryClient(mockURL string) *MockSchemaRegistryClient {
 	mockClient := &MockSchemaRegistryClient{
 		schemaRegistryURL: mockURL,
-		schemaCache:       map[string]map[int]*Schema{},
-		idCache:           map[int]*Schema{},
+		schemaVersions:    map[string]map[int]*Schema{},
+		schemaIDs:         map[int]*Schema{},
 	}
 
 	return mockClient
@@ -74,7 +74,7 @@ func (mck *MockSchemaRegistryClient) SetSchema(id int, subject string, schema st
 		return nil, errInvalidSchemaType
 	}
 
-	resultFromSchemaCache, ok := mck.schemaCache[subject]
+	resultFromSchemaCache, ok := mck.schemaVersions[subject]
 	if !ok {
 		return mck.generateVersion(id, subject, schema, schemaType, version)
 	}
@@ -96,7 +96,7 @@ func (mck *MockSchemaRegistryClient) SetSchema(id int, subject string, schema st
 
 // GetSchema Returns a Schema for the given ID
 func (mck *MockSchemaRegistryClient) GetSchema(schemaID int) (*Schema, error) {
-	thisSchema, ok := mck.idCache[schemaID]
+	thisSchema, ok := mck.schemaIDs[schemaID]
 	if !ok {
 		posErr := url.Error{
 			Op:  "GET",
@@ -134,7 +134,7 @@ func (mck *MockSchemaRegistryClient) GetSchemaVersions(subject string) ([]int, e
 // GetSchemaByVersion Returns the given Schema according to the passed in subject and version number
 func (mck *MockSchemaRegistryClient) GetSchemaByVersion(subject string, version int) (*Schema, error) {
 	var schema *Schema
-	schemaVersionMap, ok := mck.schemaCache[subject]
+	schemaVersionMap, ok := mck.schemaVersions[subject]
 	if !ok {
 		posErr := url.Error{
 			Op:  "GET",
@@ -165,7 +165,7 @@ func (mck *MockSchemaRegistryClient) GetSchemaByVersion(subject string, version 
 func (mck *MockSchemaRegistryClient) GetSubjects() ([]string, error) {
 	var allSubjects []string
 
-	for subject := range mck.schemaCache {
+	for subject := range mck.schemaVersions {
 		allSubjects = append(allSubjects, subject)
 	}
 
@@ -179,13 +179,13 @@ func (mck *MockSchemaRegistryClient) GetSubjectsIncludingDeleted() ([]string, er
 
 // DeleteSubject removes given subject from the cache
 func (mck *MockSchemaRegistryClient) DeleteSubject(subject string, _ bool) error {
-	delete(mck.schemaCache, subject)
+	delete(mck.schemaVersions, subject)
 	return nil
 }
 
 // DeleteSubjectByVersion removes given subject's version from cache
 func (mck *MockSchemaRegistryClient) DeleteSubjectByVersion(subject string, version int, _ bool) error {
-	_, ok := mck.schemaCache[subject]
+	_, ok := mck.schemaVersions[subject]
 	if !ok {
 		posErr := url.Error{
 			Op:  "DELETE",
@@ -195,9 +195,9 @@ func (mck *MockSchemaRegistryClient) DeleteSubjectByVersion(subject string, vers
 		return &posErr
 	}
 
-	for schemaVersion := range mck.schemaCache[subject] {
+	for schemaVersion := range mck.schemaVersions[subject] {
 		if schemaVersion == version {
-			delete(mck.schemaCache[subject], schemaVersion)
+			delete(mck.schemaVersions[subject], schemaVersion)
 			return nil
 		}
 	}
@@ -276,17 +276,20 @@ qualify for key/value subjects, it expects to have a `concrete subject` passed o
 
 // generateVersion the next version of the schema for the given subject, givenVersion can be set to -1 to generate one.
 func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, schema string, schemaType SchemaType, givenVersion int) (*Schema, error) {
-	versions := mck.allVersions(subject)
 	schemaVersionMap := map[int]*Schema{}
 	currentVersion := 1
 
-	// Determine if a version was given
 	if givenVersion >= 0 {
 		currentVersion = givenVersion
-	} else {
-		// Otherwise, determine if we need to generate one from existing versions
-		if len(versions) > 0 {
-			schemaVersionMap = mck.schemaCache[subject]
+	}
+
+	// if existing versions are found, make sure to load in the version map
+	if existingMap := mck.schemaVersions[subject]; len(existingMap) > 0 {
+		schemaVersionMap = existingMap
+
+		// If no version was given, and existing versions are found, +1 the new number from the latest version
+		if givenVersion <= 0 {
+			versions := mck.allVersions(subject)
 			currentVersion = versions[len(versions)-1] + 1
 		}
 	}
@@ -306,8 +309,8 @@ func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, sch
 	}
 
 	schemaVersionMap[currentVersion] = schemaToRegister
-	mck.schemaCache[subject] = schemaVersionMap
-	mck.idCache[schemaToRegister.id] = schemaToRegister
+	mck.schemaVersions[subject] = schemaVersionMap
+	mck.schemaIDs[schemaToRegister.id] = schemaToRegister
 
 	return schemaToRegister, nil
 }
@@ -315,7 +318,7 @@ func (mck *MockSchemaRegistryClient) generateVersion(id int, subject string, sch
 // allVersions returns all versions for a given subject, assumes it exists
 func (mck *MockSchemaRegistryClient) allVersions(subject string) []int {
 	var versions []int
-	result, ok := mck.schemaCache[subject]
+	result, ok := mck.schemaVersions[subject]
 
 	if ok {
 		for version := range result {

--- a/schemaRegistryClientIntegration_test.go
+++ b/schemaRegistryClientIntegration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package srclient
@@ -14,6 +15,7 @@ var srclientUrl string = os.Getenv(srclientUrlEnvName)
 var client *SchemaRegistryClient = CreateSchemaRegistryClient(srclientUrl)
 
 func TestGetSubjects(t *testing.T) {
+	t.Parallel()
 	subjects, err := client.GetSubjects()
 	if err != nil {
 		t.Fatal(err.Error())
@@ -22,6 +24,7 @@ func TestGetSubjects(t *testing.T) {
 }
 
 func TestCreateSchema(t *testing.T) {
+	t.Parallel()
 	subject := "LongList"
 	schema := `{
 		"type": "record",

--- a/schemaRegistryClient_test.go
+++ b/schemaRegistryClient_test.go
@@ -23,6 +23,7 @@ func bodyToString(in io.ReadCloser) string {
 }
 
 func TestSchemaRegistryClient_CreateSchemaWithoutReferences(t *testing.T) {
+	t.Parallel()
 
 	{
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -112,6 +113,7 @@ func TestSchemaRegistryClient_CreateSchemaWithoutReferences(t *testing.T) {
 }
 
 func TestSchemaRegistryClient_LookupSchemaWithoutReferences(t *testing.T) {
+	t.Parallel()
 	var errorCode int
 	var errorMessage string
 	{
@@ -284,6 +286,7 @@ func TestSchemaRegistryClient_LookupSchemaWithoutReferences(t *testing.T) {
 }
 
 func TestSchemaRegistryClient_GetSchemaByIDWithReferences(t *testing.T) {
+	t.Parallel()
 	{
 		refs := []Reference{
 			{Name: "name1", Subject: "subject1", Version: 1},
@@ -350,6 +353,7 @@ func TestSchemaRegistryClient_GetSchemaByIDWithReferences(t *testing.T) {
 }
 
 func TestSchemaRegistryClient_GetSchemaByVersionWithReferences(t *testing.T) {
+	t.Parallel()
 	{
 		refs := []Reference{
 			{Name: "name1", Subject: "subject1", Version: 1},
@@ -416,6 +420,7 @@ func TestSchemaRegistryClient_GetSchemaByVersionWithReferences(t *testing.T) {
 }
 
 func TestSchemaRegistryClient_GetSchemaByVersionReturnsValueFromCache(t *testing.T) {
+	t.Parallel()
 	{
 		server, call := mockServerFromSubjectVersionPairWithSchemaResponse(t, "test1", "1", schemaResponse{
 			Subject:    "test1",
@@ -441,6 +446,7 @@ func TestSchemaRegistryClient_GetSchemaByVersionReturnsValueFromCache(t *testing
 }
 
 func TestSchemaRegistryClient_GetLatestSchemaReturnsValueFromCache(t *testing.T) {
+	t.Parallel()
 	server, call := mockServerFromSubjectVersionPairWithSchemaResponse(t, "test1-value", "latest", schemaResponse{
 		Subject:    "test1",
 		Version:    1,
@@ -464,6 +470,7 @@ func TestSchemaRegistryClient_GetLatestSchemaReturnsValueFromCache(t *testing.T)
 }
 
 func TestSchemaRegistryClient_GetSchemaType(t *testing.T) {
+	t.Parallel()
 	{
 		expectedSchemaType := Json
 		server, call := mockServerFromSubjectVersionPairWithSchemaResponse(t, "test1-value", "latest", schemaResponse{
@@ -503,6 +510,7 @@ func TestSchemaRegistryClient_GetSchemaType(t *testing.T) {
 }
 
 func TestSchemaRegistryClient_JsonSchemaParses(t *testing.T) {
+	t.Parallel()
 	{
 		server, call := mockServerFromSubjectVersionPairWithSchemaResponse(t, "test1-value", "latest", schemaResponse{
 			Subject:    "test1",
@@ -543,6 +551,7 @@ func TestSchemaRegistryClient_JsonSchemaParses(t *testing.T) {
 }
 
 func TestNewSchema(t *testing.T) {
+	t.Parallel()
 	const (
 		anId        = 3
 		aSchema     = "payload"
@@ -604,69 +613,72 @@ func TestNewSchema(t *testing.T) {
 }
 
 func TestSchemaRequestMarshal(t *testing.T) {
-	tests := map[string]struct{
-		schema string
+	t.Parallel()
+	tests := map[string]struct {
+		schema     string
 		schemaType SchemaType
 		references []Reference
-		expected string
+		expected   string
 	}{
 		"avro": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Avro,
-			expected: `{"schema":"test2"}`,
+			expected:   `{"schema":"test2"}`,
 		},
 		"protobuf": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Protobuf,
-			expected: `{"schema":"test2","schemaType":"PROTOBUF"}`,
+			expected:   `{"schema":"test2","schemaType":"PROTOBUF"}`,
 		},
 		"json": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Json,
-			expected: `{"schema":"test2","schemaType":"JSON"}`,
+			expected:   `{"schema":"test2","schemaType":"JSON"}`,
 		},
 		"avro-empty-ref": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Avro,
 			references: make([]Reference, 0),
-			expected: `{"schema":"test2"}`,
+			expected:   `{"schema":"test2"}`,
 		},
 		"protobuf-empty-ref": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Protobuf,
 			references: make([]Reference, 0),
-			expected: `{"schema":"test2","schemaType":"PROTOBUF"}`,
+			expected:   `{"schema":"test2","schemaType":"PROTOBUF"}`,
 		},
 		"json-empty-ref": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Json,
 			references: make([]Reference, 0),
-			expected: `{"schema":"test2","schemaType":"JSON"}`,
+			expected:   `{"schema":"test2","schemaType":"JSON"}`,
 		},
 		"avro-ref": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Avro,
 			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
-			expected: `{"schema":"test2","references":[{"name":"name1","subject":"subject1","version":1}]}`,
+			expected:   `{"schema":"test2","references":[{"name":"name1","subject":"subject1","version":1}]}`,
 		},
 		"protobuf-ref": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Protobuf,
 			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
-			expected: `{"schema":"test2","schemaType":"PROTOBUF","references":[{"name":"name1","subject":"subject1","version":1}]}`,
+			expected:   `{"schema":"test2","schemaType":"PROTOBUF","references":[{"name":"name1","subject":"subject1","version":1}]}`,
 		},
 		"json-ref": {
-			schema: `test2`,
+			schema:     `test2`,
 			schemaType: Json,
 			references: []Reference{{Name: "name1", Subject: "subject1", Version: 1}},
-			expected: `{"schema":"test2","schemaType":"JSON","references":[{"name":"name1","subject":"subject1","version":1}]}`,
+			expected:   `{"schema":"test2","schemaType":"JSON","references":[{"name":"name1","subject":"subject1","version":1}]}`,
 		},
 	}
 
 	for name, testData := range tests {
+		testData := testData
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			schemaReq := schemaRequest{
-				Schema: testData.schema,
+				Schema:     testData.schema,
 				SchemaType: testData.schemaType.String(),
 				References: testData.references,
 			}


### PR DESCRIPTION
Did a few. things, with the removal of the `else` being the main update.

- Make tests run in parallel
- Rename unexported mock properties to better reflect purpose (they aren't caches)
- Fix existing schemas not loading if a version is given in `SetSchema`

If you're not interested in the rename or parallel I can remove those changes
