### PR TITLE
Add support for confluent.cloud bearer token authentication

### DIFF
--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -660,7 +661,11 @@ func (client *SchemaRegistryClient) httpRequest(method, uri string, payload io.R
 		if len(client.credentials.username) > 0 && len(client.credentials.password) > 0 {
 			req.SetBasicAuth(client.credentials.username, client.credentials.password)
 		} else if len(client.credentials.bearerToken) > 0 {
-			req.Header.Add("Authorization", "Bearer "+client.credentials.bearerToken)
+			if strings.Contains(strings.ToLower(uri), "confluent.cloud") {
+				req.Header.Add("Authorization", "Basic "+client.credentials.bearerToken)
+			} else {
+				req.Header.Add("Authorization", "Bearer "+client.credentials.bearerToken)
+			}
 		}
 	}
 	req.Header.Set("Content-Type", contentType)


### PR DESCRIPTION
This adds a check for confluent.cloud that changes authentication to match the requested "basic" header.