### PR TITLE
Add preallocations, add constructor with fuctional options

### DIFF
--- a/EXAMPLES_AVRO.md
+++ b/EXAMPLES_AVRO.md
@@ -44,7 +44,7 @@ func main() {
 	}()
 
 	// 2) Fetch the latest version of the schema, or create a new one if it is the first
-	schemaRegistryClient := srclient.CreateSchemaRegistryClient("http://localhost:8081")
+	schemaRegistryClient := srclient.NewSchemaRegistryClient("http://localhost:8081")
 	schema, err := schemaRegistryClient.GetLatestSchema(topic)
 	if schema == nil {
 		schemaBytes, _ := ioutil.ReadFile("complexType.avsc")
@@ -105,7 +105,7 @@ func main() {
 	c.SubscribeTopics([]string{"myTopic", "^aRegex.*[Tt]opic"}, nil)
 
 	// 2) Create a instance of the client to retrieve the schemas for each message
-	schemaRegistryClient := srclient.CreateSchemaRegistryClient("http://localhost:8081")
+	schemaRegistryClient := srclient.NewSchemaRegistryClient("http://localhost:8081")
 
 	for {
 		msg, err := c.ReadMessage(-1)

--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -163,10 +163,12 @@ func (mck *MockSchemaRegistryClient) GetSchemaByVersion(subject string, version 
 
 // GetSubjects Returns all registered subjects
 func (mck *MockSchemaRegistryClient) GetSubjects() ([]string, error) {
-	var allSubjects []string
+	allSubjects := make([]string, len(mck.schemaVersions))
 
+	var count int
 	for subject := range mck.schemaVersions {
-		allSubjects = append(allSubjects, subject)
+		allSubjects[count] = subject
+		count++
 	}
 
 	return allSubjects, nil
@@ -321,8 +323,13 @@ func (mck *MockSchemaRegistryClient) allVersions(subject string) []int {
 	result, ok := mck.schemaVersions[subject]
 
 	if ok {
+		versions = make([]int, len(result))
+
+		var count int
+
 		for version := range result {
-			versions = append(versions, version)
+			versions[count] = version
+			count++
 		}
 	}
 


### PR DESCRIPTION
This PR adds `NewSchemaRegistryClient` which sets default values and allows users to override specific values (such as the client, and not the semaphore weight). Aside from this, minor improvements in preallocating slices.

Related to #101 