### PR TITLE
feat(json): Add function `CodecJsonEnabled` inside ISchemaRegistryClient interface

### DIFF
--- a/mockSchemaRegistryClient.go
+++ b/mockSchemaRegistryClient.go
@@ -292,6 +292,11 @@ func (mck *MockSchemaRegistryClient) CodecCreationEnabled(bool) {
 	// Nothing because codecs do not matter in the inMem storage of schemas
 }
 
+// CodecJsonEnabled is not implemented
+func (mck *MockSchemaRegistryClient) CodecJsonEnabled(value bool) {
+	// Nothing because codecs do not matter in the inMem storage of schemas
+}
+
 // IsSchemaCompatible is not implemented
 func (mck *MockSchemaRegistryClient) IsSchemaCompatible(string, string, string, SchemaType, ...Reference) (bool, error) {
 	return false, errNotImplemented

--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -49,6 +49,7 @@ type ISchemaRegistryClient interface {
 	CachingEnabled(value bool)
 	ResetCache()
 	CodecCreationEnabled(value bool)
+	CodecJsonEnabled(value bool)
 	IsSchemaCompatible(subject, schema, version string, schemaType SchemaType, references ...Reference) (bool, error)
 }
 


### PR DESCRIPTION
This function already exists : func (client *SchemaRegistryClient) CodecJsonEnabled(value bool) but is currently not exposed in the interface