### PR TITLE
bugfix: Use url.PathEscape for path arguments

### DIFF
--- a/schemaRegistryClient.go
+++ b/schemaRegistryClient.go
@@ -340,7 +340,7 @@ func (client *SchemaRegistryClient) GetSubjectVersionsById(schemaID int) (Subjec
 
 // GetSchemaVersions returns a list of versions from a given subject.
 func (client *SchemaRegistryClient) GetSchemaVersions(subject string) ([]int, error) {
-	resp, err := client.httpRequest("GET", fmt.Sprintf(subjectVersions, url.QueryEscape(subject)), nil)
+	resp, err := client.httpRequest("GET", fmt.Sprintf(subjectVersions, url.PathEscape(subject)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (client *SchemaRegistryClient) ChangeSubjectCompatibilityLevel(subject stri
 	}
 	payload := bytes.NewBuffer(configChangeReqBytes)
 
-	resp, err := client.httpRequest("PUT", fmt.Sprintf(configBySubject, url.QueryEscape(subject)), payload)
+	resp, err := client.httpRequest("PUT", fmt.Sprintf(configBySubject, url.PathEscape(subject)), payload)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +396,7 @@ func (client *SchemaRegistryClient) GetGlobalCompatibilityLevel() (*Compatibilit
 // GetCompatibilityLevel returns the compatibility level of the subject.
 // If defaultToGlobal is set to true and no compatibility level is set on the subject, the global compatibility level is returned.
 func (client *SchemaRegistryClient) GetCompatibilityLevel(subject string, defaultToGlobal bool) (*CompatibilityLevel, error) {
-	resp, err := client.httpRequest("GET", fmt.Sprintf(configBySubject+"?defaultToGlobal=%t", url.QueryEscape(subject), defaultToGlobal), nil)
+	resp, err := client.httpRequest("GET", fmt.Sprintf(configBySubject+"?defaultToGlobal=%t", url.PathEscape(subject), defaultToGlobal), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +469,7 @@ func (client *SchemaRegistryClient) CreateSchema(subject string, schema string,
 		return nil, err
 	}
 	payload := bytes.NewBuffer(schemaBytes)
-	resp, err := client.httpRequest("POST", fmt.Sprintf(subjectVersions, url.QueryEscape(subject)), payload)
+	resp, err := client.httpRequest("POST", fmt.Sprintf(subjectVersions, url.PathEscape(subject)), payload)
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +526,7 @@ func (client *SchemaRegistryClient) LookupSchema(subject string, schema string, 
 		return nil, err
 	}
 	payload := bytes.NewBuffer(schemaBytes)
-	resp, err := client.httpRequest("POST", fmt.Sprintf(subjectBySubject, url.QueryEscape(subject)), payload)
+	resp, err := client.httpRequest("POST", fmt.Sprintf(subjectBySubject, url.PathEscape(subject)), payload)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func (client *SchemaRegistryClient) IsSchemaCompatible(subject, schema, version 
 	}
 	payload := bytes.NewBuffer(schemaReqBytes)
 
-	url := fmt.Sprintf("/compatibility/subjects/%s/versions/%s", subject, version)
+	url := fmt.Sprintf("/compatibility/subjects/%s/versions/%s", url.PathEscape(subject), version)
 	resp, err := client.httpRequest("POST", url, payload)
 	if err != nil {
 		return false, err
@@ -603,7 +603,7 @@ func (client *SchemaRegistryClient) IsSchemaCompatible(subject, schema, version 
 
 // DeleteSubject deletes
 func (client *SchemaRegistryClient) DeleteSubject(subject string, permanent bool) error {
-	uri := "/subjects/" + subject
+	uri := "/subjects/" + url.PathEscape(subject)
 	_, err := client.httpRequest("DELETE", uri, nil)
 	if err != nil || !permanent {
 		return err
@@ -616,7 +616,7 @@ func (client *SchemaRegistryClient) DeleteSubject(subject string, permanent bool
 
 // DeleteSubjectByVersion deletes the version of the scheme
 func (client *SchemaRegistryClient) DeleteSubjectByVersion(subject string, version int, permanent bool) error {
-	uri := fmt.Sprintf(subjectByVersion, subject, strconv.Itoa(version))
+	uri := fmt.Sprintf(subjectByVersion, url.PathEscape(subject), strconv.Itoa(version))
 	_, err := client.httpRequest("DELETE", uri, nil)
 	if err != nil || !permanent {
 		return err
@@ -692,7 +692,7 @@ func (client *SchemaRegistryClient) getVersion(subject string, version string) (
 		}
 	}
 
-	resp, err := client.httpRequest("GET", fmt.Sprintf(subjectByVersion, url.QueryEscape(subject), version), nil)
+	resp, err := client.httpRequest("GET", fmt.Sprintf(subjectByVersion, url.PathEscape(subject), version), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Why?
There is a bug detected when, for example, a subject contains space characters.

The package currently uses `+` to encode space in path instead of `%20`.

There might be other encoding issues I'm not aware of.

What?
I search through code for usage of `httpRequest` and reviewed all calls to make sure they use url.PathEscape when encoding path parameters.

Some were using url.QueryEscape. Some had no escaping.

Addresses:
https://github.com/riferrei/srclient/issues/113